### PR TITLE
Fix `test_nonnumeric_magnitudes`

### DIFF
--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -410,7 +410,13 @@ class TestQuantityToCompact(QuantityTestCase):
     def test_nonnumeric_magnitudes(self):
         ureg = self.ureg
         x = "some string"*ureg.m
-        self.assertRaises(RuntimeError, self.compareQuantity_compact(x,x))
+        warning = RuntimeWarning
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter('always')
+            self.compareQuantity_compact(x, x)
+            self.assertTrue(
+                any(item.category == warning for item in warning_list)
+            )
 
 class TestQuantityBasicMath(QuantityTestCase):
 


### PR DESCRIPTION
The test for non-numeric magnitudes was using `assertRaises` incorrectly.  While the context-manager form should be preferred, with the given style it should be passed the function to test, not the result of the function.

```python
# Wrong
self.assertRaises(RuntimeError, self.compareQuantity_compact(x,x))

# Better
self.assertRaises(RuntimeError, self.compareQuantity_compact, x, x)

# Best
with self.assertRaises(RuntimeError):
    self.compareQuantity_compact(x,x)
```

While fixing this I found that `RuntimeError` was not being raised, instead a `RuntimeWarning` was being issued.  Since `unittest.TestCase.assertWarns` was not added until Python 3.2 (see [docs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertWarns)), I'm testing for the warning as recommended in the [Python 2.7 docs](https://docs.python.org/2/library/warnings.html#testing-warnings).

Fixes hgrecco/pint#659